### PR TITLE
Add dibt-tgl translation

### DIFF
--- a/community_tasks/filbench_evals.py
+++ b/community_tasks/filbench_evals.py
@@ -29,6 +29,7 @@ This file generally creates just a TASKS_TABLE and TASKS_GROUPS which are then i
 
 from filbench.belebele import FILIPINO_BELEBELE_TASKS
 from filbench.dengue_filipino import FILIPINO_DENGUE_TASKS
+from filbench.dibt import FILIPINO_DIBT_TASKS
 from filbench.firecs import FILIPINO_FIRECS_TASK
 from filbench.global_mmlu import FILIPINO_GLOBAL_MMLU_TASKS
 from filbench.include import FILIPINO_INCLUDE_TASKS
@@ -49,4 +50,5 @@ TASKS_TABLE: list[LightevalTaskConfig] = (
     + FILIPINO_DENGUE_TASKS
     + FILIPINO_NTREX_TASK
     + FILIPINO_TICO19_TASKS
+    + FILIPINO_DIBT_TASKS
 )

--- a/examples/tasks/all_filbench_tasks.txt
+++ b/examples/tasks/all_filbench_tasks.txt
@@ -78,3 +78,4 @@ filbench|global_mmlu_all_tgl_mcf:sociology
 filbench|global_mmlu_all_tgl_mcf:us_foreign_policy
 filbench|global_mmlu_all_tgl_mcf:virology
 filbench|global_mmlu_all_tgl_mcf:world_religions
+filbench|dibt_translation_tgl

--- a/filbench/dibt.py
+++ b/filbench/dibt.py
@@ -1,0 +1,63 @@
+# MIT License
+
+# Copyright (c) 2024 The HuggingFace Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# ruff: noqa: F405, F403, F401
+"""
+Manually annotated translation dataset for English to Tagalog (Filipino) from the
+FilBench team.
+
+Dataset link: https://huggingface.co/datasets/gmnlp/tico19/viewer/en-tl
+"""
+
+from lighteval.metrics.metrics import Metrics
+from lighteval.tasks.lighteval_task import LightevalTaskConfig
+from lighteval.tasks.templates.translation import get_translation_prompt_function
+from lighteval.tasks.templates.utils.formulation import CFFormulation
+from lighteval.utils.language import Language
+
+
+FILIPINO_DIBT_TASKS = [
+    LightevalTaskConfig(
+        name="dibt_translation_tgl",
+        prompt_function=get_translation_prompt_function(
+            source_language=Language.ENGLISH,
+            target_language=Language.TAGALOG,
+            adapter=lambda line: {
+                "source_text": line["source"],
+                "target_text": [entry["value"] for entry in line["target"]],
+            },
+            formulation=CFFormulation(),
+        ),
+        suite=("filbench",),
+        hf_repo="data-is-better-together/MPEP_FILIPINO",
+        metric=[
+            Metrics.rougeL,
+            Metrics.bleu,
+            Metrics.bleurt,
+            Metrics.chrf,
+            Metrics.ter,
+        ],
+        evaluation_splits=["train"],
+        trust_dataset=True,
+        generation_size=64,
+    )
+]

--- a/filbench/dibt.py
+++ b/filbench/dibt.py
@@ -43,8 +43,7 @@ FILIPINO_DIBT_TASKS = [
             target_language=Language.TAGALOG,
             adapter=lambda line: {
                 "source_text": line["source"],
-                "target_text": [entry["value"] for entry in line["target"]] + [line["target-suggestion"]],
-                "gold_idx": list(range(len(line["target"]))),
+                "target_text": line["target"][0]["value"],
             },
             formulation=CFFormulation(),
         ),
@@ -60,6 +59,6 @@ FILIPINO_DIBT_TASKS = [
         ],
         evaluation_splits=["train"],
         trust_dataset=True,
-        generation_size=64,
+        generation_size=1,
     )
 ]

--- a/filbench/dibt.py
+++ b/filbench/dibt.py
@@ -43,12 +43,14 @@ FILIPINO_DIBT_TASKS = [
             target_language=Language.TAGALOG,
             adapter=lambda line: {
                 "source_text": line["source"],
-                "target_text": [entry["value"] for entry in line["target"]],
+                "target_text": [entry["value"] for entry in line["target"]] + [line["target-suggestion"]],
+                "gold_idx": list(range(len(line["target"]))),
             },
             formulation=CFFormulation(),
         ),
         suite=("filbench",),
-        hf_repo="data-is-better-together/MPEP_FILIPINO",
+        hf_repo="DIBT/MPEP_FILIPINO",
+        hf_subset="default",
         metric=[
             Metrics.rougeL,
             Metrics.bleu,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ad9bf715-9979-46b3-ae1a-8a4146023f18)
This one is interesting because [for some entries there are multiple targets](https://huggingface.co/datasets/data-is-better-together/MPEP_FILIPINO) - i.e. more than one of us translated the same prompt. If you pass in multiple strings under "target text" then the prompt formatter will recognize both as valid and will create gold_idx for both of them. Not 100% sure yet what the behavior is (stepping through with debugger now) but my expectation is that it should accept either as valid.